### PR TITLE
Rename Polygon -> Path and remove unused functions

### DIFF
--- a/src/cq_cam/operations/strategy.py
+++ b/src/cq_cam/operations/strategy.py
@@ -1,16 +1,12 @@
 import logging
+from itertools import pairwise
 from typing import Dict, List, Tuple
 
 import cadquery as cq
 import numpy as np
 
 from cq_cam.utils.linked_polygon import LinkedPolygon
-from cq_cam.utils.utils import (
-    WireClipper,
-    cached_dist2,
-    dist_to_segment_squared,
-    pairwise,
-)
+from cq_cam.utils.utils import WireClipper, cached_dist2, dist_to_segment_squared
 
 Scanpoint = Tuple[float, float]
 Scanline = List[Scanpoint]

--- a/src/cq_cam/routers.py
+++ b/src/cq_cam/routers.py
@@ -15,14 +15,13 @@ from cq_cam.command import (
     Plunge,
     Rapid,
 )
-from cq_cam.utils.geometry_op import PolyFace, Polygon, distance_to_polygon
+from cq_cam.utils.geometry_op import Path, PathFace, distance_to_path
 from cq_cam.utils.utils import (
     edge_end_param,
     edge_end_point,
     edge_start_param,
     edge_start_point,
     is_arc_clockwise2,
-    pairwise,
     wire_to_ordered_edges,
 )
 
@@ -233,13 +232,13 @@ def route_wires(job: "Job", wires: List[Union[cq.Wire, cq.Edge]], stepover=None)
     return commands
 
 
-def shift_polygon(polygon: Polygon, i: int):
+def shift_polygon(polygon: Path, i: int):
     polygon = polygon[:-1]
     polygon = polygon[i:] + polygon[: i + 1]
     return polygon
 
 
-def route_polyface_outers(job: "Job", polyfaces: List[PolyFace], stepover=None):
+def route_polyface_outers(job: "Job", polyfaces: List[PathFace], stepover=None):
     commands = []
     previous_wire = None
     previous_wire_start = None
@@ -252,7 +251,7 @@ def route_polyface_outers(job: "Job", polyfaces: List[PolyFace], stepover=None):
         # Determine how to access the wire
         # Direct plunge option
         if previous_wire_end:
-            distance, closest_point, poly_position = distance_to_polygon(
+            distance, closest_point, poly_position = distance_to_path(
                 previous_wire_end, poly
             )
         else:

--- a/src/cq_cam/utils/tests/test_polyface.py
+++ b/src/cq_cam/utils/tests/test_polyface.py
@@ -2,7 +2,7 @@ from typing import List
 
 import cadquery as cq
 
-from cq_cam.utils.geometry_op import make_polyfaces, wire_to_polygon
+from cq_cam.utils.geometry_op import make_polyfaces, wire_to_path
 from cq_cam.utils.tests.conftest import shift_polygon
 
 
@@ -26,8 +26,8 @@ def test_make_polyface():
     inners = []
     faces: List[cq.Face] = wp.objects
     for face in faces:
-        outers.append(wire_to_polygon(face.outerWire()))
-        inners += [wire_to_polygon(inner) for inner in face.innerWires()]
+        outers.append(wire_to_path(face.outerWire()))
+        inners += [wire_to_path(inner) for inner in face.innerWires()]
 
     polyfaces = make_polyfaces(outers, inners, 0)
     assert len(polyfaces) == 2

--- a/src/cq_cam/utils/tests/test_segment_math.py
+++ b/src/cq_cam/utils/tests/test_segment_math.py
@@ -1,4 +1,4 @@
-from cq_cam.utils.geometry_op import distance_to_polygon
+from cq_cam.utils.geometry_op import distance_to_path
 from cq_cam.utils.utils import dist_to_segment_squared
 
 
@@ -22,10 +22,10 @@ def test_dist_to_segment_squared():
     assert a, (round(b[0], 2), round(b[1], 2)) == (0.04, (0.12, 0.84))
 
 
-def test_distance_to_polygon():
+def test_distance_to_path():
     point = (0, 1)
-    polygon = [(-1, 0), (0, 0), (1, 1), (1, 2)]
-    distance, closest_point, poly_position = distance_to_polygon(point, polygon)
+    path = [(-1, 0), (0, 0), (1, 1), (1, 2)]
+    distance, closest_point, poly_position = distance_to_path(point, path)
 
     assert distance == 0.5
     assert closest_point == (0.5, 0.5)


### PR DESCRIPTION
Rationale for renaming is

a) Path is shorter
b) Path can represent OpenPath and ClosedPath better than the term Polygon, IMO