### PR TITLE
Add automatic support for ocp-vscode

### DIFF
--- a/src/cq_cam/tests/test_fluent.py
+++ b/src/cq_cam/tests/test_fluent.py
@@ -12,16 +12,21 @@ def to_occ_color():
     _cq_utils.to_occ_color = lambda x: Quantity_Color(0, 0, 0, Quantity_TOC_RGB)
 
 
+@pytest.fixture
+def show_object():
+    def show_object(*args, **kwargs):
+        return None
+
+    return show_object
+
+
 def test_fluent_show__no_show_object(job, top_face):
     job = job.profile(top_face)
     with pytest.raises(ValueError):
         job.show()
 
 
-def test_fluent_show__cq_editor(job, top_face, caplog):
-    def show_object(*args, **kwargs):
-        pass
-
+def test_fluent_show__cq_editor(job, top_face, caplog, show_object):
     show_object.__module__ = "cq_editor.test"
 
     job = job.profile(top_face)
@@ -29,10 +34,7 @@ def test_fluent_show__cq_editor(job, top_face, caplog):
     assert "Unsupported show_object source module" not in caplog.text
 
 
-def test_fluent_show__ocp_vscode(job, top_face, caplog):
-    def show_object(*args, **kwargs):
-        pass
-
+def test_fluent_show__ocp_vscode(job, top_face, caplog, show_object):
     show_object.__module__ = "ocp_vscode.test"
 
     job = job.profile(top_face)
@@ -40,10 +42,7 @@ def test_fluent_show__ocp_vscode(job, top_face, caplog):
     assert "Unsupported show_object source module" not in caplog.text
 
 
-def test_fluent_show__unknown(job, top_face, caplog):
-    def show_object(*args, **kwargs):
-        pass
-
+def test_fluent_show__unknown(job, top_face, caplog, show_object):
     show_object.__module__ = "unknown.test"
 
     job = job.profile(top_face)
@@ -52,10 +51,7 @@ def test_fluent_show__unknown(job, top_face, caplog):
     assert "Unsupported show_object source module (unknown)" in caplog.text
 
 
-def test_fluent_show__autodiscovery(job, top_face, caplog):
-    def show_object(*args, **kwargs):
-        pass
-
+def test_fluent_show__autodiscovery(job, top_face, caplog, show_object):
     show_object.__module__ = "cq_editor.test"
     import __main__
 

--- a/src/cq_cam/tests/test_fluent.py
+++ b/src/cq_cam/tests/test_fluent.py
@@ -1,4 +1,15 @@
+import sys
+from unittest.mock import Mock
+
 import pytest
+from OCP.Quantity import Quantity_Color, Quantity_TOC_RGB
+
+
+@pytest.fixture(autouse=True)
+def to_occ_color():
+    _cq_utils = Mock()
+    sys.modules["cq_editor.cq_utils"] = _cq_utils
+    _cq_utils.to_occ_color = lambda x: Quantity_Color(0, 0, 0, Quantity_TOC_RGB)
 
 
 def test_fluent_show__no_show_object(job, top_face):

--- a/src/cq_cam/tests/test_fluent.py
+++ b/src/cq_cam/tests/test_fluent.py
@@ -1,0 +1,56 @@
+import pytest
+
+
+def test_fluent_show__no_show_object(job, top_face):
+    job = job.profile(top_face)
+    with pytest.raises(ValueError):
+        job.show()
+
+
+def test_fluent_show__cq_editor(job, top_face, caplog):
+    def show_object(*args, **kwargs):
+        pass
+
+    show_object.__module__ = "cq_editor.test"
+
+    job = job.profile(top_face)
+    job.show(show_object)
+    assert "Unsupported show_object source module" not in caplog.text
+
+
+def test_fluent_show__ocp_vscode(job, top_face, caplog):
+    def show_object(*args, **kwargs):
+        pass
+
+    show_object.__module__ = "ocp_vscode.test"
+
+    job = job.profile(top_face)
+    job.show(show_object)
+    assert "Unsupported show_object source module" not in caplog.text
+
+
+def test_fluent_show__unknown(job, top_face, caplog):
+    def show_object(*args, **kwargs):
+        pass
+
+    show_object.__module__ = "unknown.test"
+
+    job = job.profile(top_face)
+    job.show(show_object)
+
+    assert "Unsupported show_object source module (unknown)" in caplog.text
+
+
+def test_fluent_show__autodiscovery(job, top_face, caplog):
+    def show_object(*args, **kwargs):
+        pass
+
+    show_object.__module__ = "cq_editor.test"
+    import __main__
+
+    __main__.__dict__["show_object"] = show_object
+
+    job = job.profile(top_face)
+    job.show()
+
+    assert "Unsupported show_object source module (unknown)" not in caplog.text

--- a/src/cq_cam/visualize.py
+++ b/src/cq_cam/visualize.py
@@ -45,7 +45,13 @@ def visualize_job_plane(job_plane: cq.Plane, length=1):
     return group
 
 
-def visualize_job(job_plane: cq.Plane, commands, start_height=10):
+def visualize_job(
+    job_plane: cq.Plane, commands, start_height=10
+) -> AIS_MultipleConnectedInteractive:
+    """
+    Visualize commands as AIS_Line objects grouped inside AIS_MultipleConnectedInteractive
+    This method is suitable for cq-editor as it enables the use of colours.
+    """
     inverse_transform = job_plane.rG
     position = cq.Vector(0, 0, start_height)
     command_group = AIS_MultipleConnectedInteractive()
@@ -63,13 +69,13 @@ def visualize_job(job_plane: cq.Plane, commands, start_height=10):
     return group
 
 
-def visualize_job_as_edges(job_plane: cq.Plane, commands, start_height=10):
-    """To be used mainly for documentation purposes
+def visualize_job_as_edges(
+    job_plane: cq.Plane, commands, start_height=10
+) -> list[cq.Edge]:
+    """
+    Slower generation but slightly more performant rendering compared to AIS_Line
 
-    :param job_plane:
-    :param commands:
-    :param start_height:
-    :return:
+    Used for documentation and ocp_vscode.
     """
     inverse_transform = job_plane.rG
     position = cq.Vector(0, 0, start_height)


### PR DESCRIPTION
Job.show will now auto-detect cq-editor/ocp-vscode and use the appropriate visualization strategy.

cq-editor uses the original AIS_Line based visualization.

ocp-vscode uses edge based visualization as it doesn't support AIS.

Relates to #23 